### PR TITLE
[3043][FIX] currency_rate_update

### DIFF
--- a/currency_rate_update/README.rst
+++ b/currency_rate_update/README.rst
@@ -113,6 +113,10 @@ Contributors
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
 
+* `Quartile Limited <https://www.quartile.co/>`__:
+
+  * Tatsuki Kanda <kanda@quartile.co>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/currency_rate_update/__manifest__.py
+++ b/currency_rate_update/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Currency Rate Update",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.2",
     "author": "Camptocamp, CorporateHub, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/currency",
     "license": "AGPL-3",

--- a/currency_rate_update/__manifest__.py
+++ b/currency_rate_update/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Currency Rate Update",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.1.0",
     "author": "Camptocamp, CorporateHub, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/currency",
     "license": "AGPL-3",

--- a/currency_rate_update/i18n/am.po
+++ b/currency_rate_update/i18n/am.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ar.po
+++ b/currency_rate_update/i18n/ar.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/bg.po
+++ b/currency_rate_update/i18n/bg.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/bs.po
+++ b/currency_rate_update/i18n/bs.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ca.po
+++ b/currency_rate_update/i18n/ca.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ca_ES.po
+++ b/currency_rate_update/i18n/ca_ES.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/cs.po
+++ b/currency_rate_update/i18n/cs.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/da.po
+++ b/currency_rate_update/i18n/da.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/de.po
+++ b/currency_rate_update/i18n/de.po
@@ -190,6 +190,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Währungskursaktualisierung"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Tag(e)"

--- a/currency_rate_update/i18n/el_GR.po
+++ b/currency_rate_update/i18n/el_GR.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/en_GB.po
+++ b/currency_rate_update/i18n/en_GB.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es.po
+++ b/currency_rate_update/i18n/es.po
@@ -189,6 +189,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Actualización de Tipos de Cambio (OCA) diária"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Día(s)"

--- a/currency_rate_update/i18n/es_AR.po
+++ b/currency_rate_update/i18n/es_AR.po
@@ -189,6 +189,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Actualizar Tasas de Cambio (OCA) diariamente"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Dia(s)"

--- a/currency_rate_update/i18n/es_CL.po
+++ b/currency_rate_update/i18n/es_CL.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_CO.po
+++ b/currency_rate_update/i18n/es_CO.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_CR.po
+++ b/currency_rate_update/i18n/es_CR.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_DO.po
+++ b/currency_rate_update/i18n/es_DO.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_EC.po
+++ b/currency_rate_update/i18n/es_EC.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_ES.po
+++ b/currency_rate_update/i18n/es_ES.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_MX.po
+++ b/currency_rate_update/i18n/es_MX.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_PE.po
+++ b/currency_rate_update/i18n/es_PE.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_PY.po
+++ b/currency_rate_update/i18n/es_PY.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/es_VE.po
+++ b/currency_rate_update/i18n/es_VE.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/et.po
+++ b/currency_rate_update/i18n/et.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/eu.po
+++ b/currency_rate_update/i18n/eu.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/fa.po
+++ b/currency_rate_update/i18n/fa.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/fi.po
+++ b/currency_rate_update/i18n/fi.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/fr.po
+++ b/currency_rate_update/i18n/fr.po
@@ -194,6 +194,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Mise à jour du taux de la devise"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Jour(s)"

--- a/currency_rate_update/i18n/fr_CA.po
+++ b/currency_rate_update/i18n/fr_CA.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/fr_CH.po
+++ b/currency_rate_update/i18n/fr_CH.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/gl.po
+++ b/currency_rate_update/i18n/gl.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/gl_ES.po
+++ b/currency_rate_update/i18n/gl_ES.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/gu.po
+++ b/currency_rate_update/i18n/gu.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/he.po
+++ b/currency_rate_update/i18n/he.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/hr.po
+++ b/currency_rate_update/i18n/hr.po
@@ -189,6 +189,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Ažuriranje tečajne liste (OCA) dnevno"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Dan(a)"

--- a/currency_rate_update/i18n/hr_HR.po
+++ b/currency_rate_update/i18n/hr_HR.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/hu.po
+++ b/currency_rate_update/i18n/hu.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/id.po
+++ b/currency_rate_update/i18n/id.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/it.po
+++ b/currency_rate_update/i18n/it.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ja.po
+++ b/currency_rate_update/i18n/ja.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ko.po
+++ b/currency_rate_update/i18n/ko.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/lt.po
+++ b/currency_rate_update/i18n/lt.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/lt_LT.po
+++ b/currency_rate_update/i18n/lt_LT.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/lv.po
+++ b/currency_rate_update/i18n/lv.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/mk.po
+++ b/currency_rate_update/i18n/mk.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/mn.po
+++ b/currency_rate_update/i18n/mn.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/nb.po
+++ b/currency_rate_update/i18n/nb.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/nb_NO.po
+++ b/currency_rate_update/i18n/nb_NO.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/nl.po
+++ b/currency_rate_update/i18n/nl.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/nl_BE.po
+++ b/currency_rate_update/i18n/nl_BE.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/pl.po
+++ b/currency_rate_update/i18n/pl.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/pt.po
+++ b/currency_rate_update/i18n/pt.po
@@ -194,6 +194,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Atualização da Taxas de Câmbio"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Dia(s)"

--- a/currency_rate_update/i18n/pt_BR.po
+++ b/currency_rate_update/i18n/pt_BR.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/pt_PT.po
+++ b/currency_rate_update/i18n/pt_PT.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ro.po
+++ b/currency_rate_update/i18n/ro.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/ru.po
+++ b/currency_rate_update/i18n/ru.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/sk.po
+++ b/currency_rate_update/i18n/sk.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/sl.po
+++ b/currency_rate_update/i18n/sl.po
@@ -192,6 +192,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Posodobitev menjalnega tečaja"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Dan(dni)"

--- a/currency_rate_update/i18n/sr.po
+++ b/currency_rate_update/i18n/sr.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/sr@latin.po
+++ b/currency_rate_update/i18n/sr@latin.po
@@ -185,6 +185,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/sv.po
+++ b/currency_rate_update/i18n/sv.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/th.po
+++ b/currency_rate_update/i18n/th.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/tr.po
+++ b/currency_rate_update/i18n/tr.po
@@ -191,6 +191,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr "Döviz Kuru Güncellemesi"
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr "Gün(ler)"

--- a/currency_rate_update/i18n/tr_TR.po
+++ b/currency_rate_update/i18n/tr_TR.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/uk.po
+++ b/currency_rate_update/i18n/uk.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/vi.po
+++ b/currency_rate_update/i18n/vi.po
@@ -183,6 +183,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/vi_VN.po
+++ b/currency_rate_update/i18n/vi_VN.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/zh_CN.po
+++ b/currency_rate_update/i18n/zh_CN.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/i18n/zh_TW.po
+++ b/currency_rate_update/i18n/zh_TW.po
@@ -184,6 +184,11 @@ msgid "Currency Rates Update (OCA) daily"
 msgstr ""
 
 #. module: currency_rate_update
+#: model:ir.model.fields,field_description:currency_rate_update.field_res_currency_rate_provider__daily
+msgid "Daily"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model.fields.selection,name:currency_rate_update.selection__res_currency_rate_provider__interval_type__days
 msgid "Day(s)"
 msgstr ""

--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -65,6 +65,7 @@ class ResCurrencyRateProvider(models.Model):
     next_run = fields.Date(
         string="Next scheduled update", default=fields.Date.today, required=True
     )
+    daily = fields.Boolean(compute="_compute_daily", store=True)
 
     _sql_constraints = [
         (
@@ -115,6 +116,13 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
+    @api.depends("interval_type", "interval_number")
+    def _compute_daily(self):
+        for provider in self:
+            provider.daily = False
+            if provider.interval_type == "days" and provider.interval_number == 1:
+                provider.daily = True
+
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -161,8 +169,11 @@ class ResCurrencyRateProvider(models.Model):
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
 
+            newest_date = False
             for content_date, rates in data:
                 timestamp = fields.Date.from_string(content_date)
+                if not newest_date or timestamp > newest_date:
+                    newest_date = timestamp
                 for currency_name, rate in rates.items():
                     if currency_name == provider.company_id.currency_id.name:
                         continue
@@ -197,16 +208,17 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
-                provider._schedule_last_successful_run()
-                provider._schedule_next_run()
+                provider._schedule_last_successful_run(newest_date)
+                provider._schedule_next_run(newest_date)
 
-    def _schedule_last_successful_run(self):
-        self.last_successful_run = self.next_run
+    def _schedule_last_successful_run(self, newest_date):
+        self.last_successful_run = newest_date
 
-    def _schedule_next_run(self):
+    def _schedule_next_run(self, newest_date):
+        # next_run is not used when daily is true, but we are updating the value anyway.
         self.ensure_one()
         self.next_run = (
-            datetime.combine(self.next_run, time.min) + self._get_next_run_period()
+            datetime.combine(newest_date, time.min) + self._get_next_run_period()
         ).date()
 
     def _process_rate(self, currency, rate):
@@ -260,11 +272,14 @@ class ResCurrencyRateProvider(models.Model):
         _logger.info("Scheduled currency rates update...")
 
         today = fields.Date.context_today(self)
+        # When daily is true, the provider should always be picked for scheduled update.
         providers = self.search(
             [
                 ("company_id.currency_rates_autoupdate", "=", True),
                 ("active", "=", True),
+                "|",
                 ("next_run", "<=", today),
+                ("daily", "=", True),
             ]
         )
         if providers:
@@ -278,9 +293,13 @@ class ResCurrencyRateProvider(models.Model):
                     if provider.last_successful_run
                     else (provider.next_run - provider._get_next_run_period())
                 )
+                newest_only = True
                 date_to = provider.next_run
-                provider._update(date_from, date_to, newest_only=True)
-
+                # Fetch next_run to today data
+                if provider.daily:
+                    newest_only = False
+                    date_to = today
+                provider._update(date_from, date_to, newest_only=newest_only)
         _logger.info("Scheduled currency rates update complete.")
 
     def _get_supported_currencies(self):

--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -115,9 +115,6 @@ class ResCurrencyRateProvider(models.Model):
                 [("name", "in", provider._get_supported_currencies())]
             )
 
-    def _get_close_time(self):
-        return False
-
     def _update(self, date_from, date_to, newest_only=False):
         Currency = self.env["res.currency"]
         CurrencyRate = self.env["res.currency.rate"]
@@ -159,8 +156,7 @@ class ResCurrencyRateProvider(models.Model):
                 continue
 
             if not data:
-                if is_scheduled:
-                    provider._schedule_next_run()
+                # Try again if there is no data yet
                 continue
             if newest_only:
                 data = [max(data, key=lambda x: fields.Date.from_string(x[0]))]
@@ -201,11 +197,14 @@ class ResCurrencyRateProvider(models.Model):
                         )
 
             if is_scheduled:
+                provider._schedule_last_successful_run()
                 provider._schedule_next_run()
+
+    def _schedule_last_successful_run(self):
+        self.last_successful_run = self.next_run
 
     def _schedule_next_run(self):
         self.ensure_one()
-        self.last_successful_run = self.next_run
         self.next_run = (
             datetime.combine(self.next_run, time.min) + self._get_next_run_period()
         ).date()
@@ -280,28 +279,8 @@ class ResCurrencyRateProvider(models.Model):
                     else (provider.next_run - provider._get_next_run_period())
                 )
                 date_to = provider.next_run
-                provider_utc_close_hour = provider._get_close_time()
-                current_utc_hour = datetime.now().hour
-                _logger.debug(
-                    "Provider %s date_to=%s today=%s provider close hour %s UTC, "
-                    "current hour %s UTC",
-                    provider.name,
-                    date_to,
-                    today,
-                    provider_utc_close_hour,
-                    current_utc_hour,
-                )
-                if (date_to != today) or (
-                    date_to == today
-                    and (
-                        not provider_utc_close_hour
-                        or current_utc_hour >= provider_utc_close_hour
-                    )
-                ):
-                    provider._update(date_from, date_to, newest_only=True)
-                    _logger.info("Currency rates updated from %s", provider.name)
-                else:
-                    _logger.info("Skip currency rate update from %s", provider.name)
+                provider._update(date_from, date_to, newest_only=True)
+
         _logger.info("Scheduled currency rates update complete.")
 
     def _get_supported_currencies(self):

--- a/currency_rate_update/models/res_currency_rate_provider.py
+++ b/currency_rate_update/models/res_currency_rate_provider.py
@@ -260,7 +260,7 @@ class ResCurrencyRateProvider(models.Model):
     def _scheduled_update(self):
         _logger.info("Scheduled currency rates update...")
 
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         providers = self.search(
             [
                 ("company_id.currency_rates_autoupdate", "=", True),

--- a/currency_rate_update/models/res_currency_rate_provider_ECB.py
+++ b/currency_rate_update/models/res_currency_rate_provider_ECB.py
@@ -19,30 +19,6 @@ class ResCurrencyRateProviderECB(models.Model):
         ondelete={"ECB": "set default"},
     )
 
-    def _get_close_time(self):
-        """According to official page "Euro foreign exchange reference rates"
-        on the ECB Website, today's rate data are available from 16:00 CET.
-        https://www.ecb.europa.eu/stats/policy_and_exchange_rates/
-        euro_reference_exchange_rates/html/index.en.html
-        It is necessary to define a blocking time to avoid the following use case:
-        - Cron record call webservice today BEFORE time x.
-        - The webservice response will not give an error but it will not return data
-        for today.
-        - The value of last_successful_run will be updated with today's date.
-        - The value of next_run will be updated to tomorrow.
-
-        You would never get the value for today and tomorrow the same thing would happen.
-
-        CET Time is UTC+2 in summer and UTC+1 in winter:
-        (https://en.wikipedia.org/wiki/Central_European_Time).
-        Block time must be set to UTC+0
-        Set time to 15, which is UTC hour that corresponds to
-        16:00 CET in winter and 17:00 CET in summer => ok with the ECB publication time
-        """
-        if self.service == "ECB":
-            return 15
-        return super()._get_close_time()
-
     def _get_supported_currencies(self):
         self.ensure_one()
         if self.service != "ECB":

--- a/currency_rate_update/readme/CONTRIBUTORS.rst
+++ b/currency_rate_update/readme/CONTRIBUTORS.rst
@@ -22,3 +22,7 @@
 * `CorporateHub <https://corporatehub.eu/>`__
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
+
+* `Quartile Limited <https://www.quartile.co/>`__:
+
+  * Tatsuki Kanda <kanda@quartile.co>

--- a/currency_rate_update/static/description/index.html
+++ b/currency_rate_update/static/description/index.html
@@ -458,6 +458,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Alexey Pelykh &lt;<a class="reference external" href="mailto:alexey.pelykh&#64;corphub.eu">alexey.pelykh&#64;corphub.eu</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co/">Quartile Limited</a>:<ul>
+<li>Tatsuki Kanda &lt;<a class="reference external" href="mailto:kanda&#64;quartile.co">kanda&#64;quartile.co</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/currency_rate_update/tests/test_currency_rate_update.py
+++ b/currency_rate_update/tests/test_currency_rate_update.py
@@ -157,8 +157,8 @@ class TestCurrencyRateUpdate(AccountTestInvoicingCommon):
         self.ecb_provider._scheduled_update()
         self.ecb_provider._scheduled_update()
 
-        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 7))
-        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 8))
+        self.assertEqual(self.ecb_provider.last_successful_run, date(2019, 7, 5))
+        self.assertEqual(self.ecb_provider.next_run, date(2019, 7, 6))
 
     def test_foreign_base_currency(self):
         self.company.currency_id = self.chf_currency

--- a/currency_rate_update/views/res_currency_rate_provider.xml
+++ b/currency_rate_update/views/res_currency_rate_provider.xml
@@ -29,7 +29,8 @@
                 <field name="update_schedule" />
                 <field name="available_currency_ids" invisible="1" />
                 <field name="currency_ids" widget="many2many_tags" />
-                <field name="next_run" />
+                <field name="daily" invisible="1" />
+                <field name="next_run" attrs="{'invisible': [('daily', '=', True)]}" />
             </tree>
         </field>
     </record>
@@ -79,7 +80,11 @@
                             <field name="last_successful_run" />
                         </group>
                         <group>
-                            <field name="next_run" />
+                            <field name="daily" invisible="1" />
+                            <field
+                                name="next_run"
+                                attrs="{'invisible': [('daily', '=', True)]}"
+                            />
                         </group>
                         <group>
                             <field name="available_currency_ids" invisible="1" />


### PR DESCRIPTION
[3043](https://www.quartile.co/web?debug=1#id=3043&action=771&model=project.task&view_type=form&menu_id=505)

Use context_today() instead of today() to search provider records against next_run.

Before this commit, scheduled updates before 09:00 a.m. would have trouble identifying the target providers for installations in Japan, for example.


[16.0][IMP] currency_rate_update: Do not call the _schedule_next_run() method if there is no data
https://github.com/OCA/currency/pull/153/files

This change allows you to make as many requests as you want on a daily basis without updating the last_successful_run and next_run fields.