### PR TITLE
[3153][IMP] purchase_analytic: analytic_distribution readonly states

### DIFF
--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -11,8 +11,8 @@ class PurchaseOrder(models.Model):
 
     analytic_distribution = fields.Json(
         inverse="_inverse_analytic_distribution",
-        readonly=True,
-        states={"draft": [("readonly", False)]},
+        # To be consistent with order_line readonly behavior
+        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
 
     @api.depends("order_line.analytic_distribution")


### PR DESCRIPTION
[3153](https://www.quartile.co/web?debug=1#id=3153&action=771&model=project.task&view_type=form&menu_id=505)

Make the behavior consistent with that of the purchase order line.