### PR TITLE
[3242][FIX] mrp_subcontracting_analytic: switch to extend _subcontracted_produce()

### DIFF
--- a/mrp_subcontracting_analytic/models/stock_picking.py
+++ b/mrp_subcontracting_analytic/models/stock_picking.py
@@ -7,7 +7,13 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
-        vals = super()._prepare_subcontract_mo_vals(subcontract_move, bom)
-        vals["analytic_distribution"] = subcontract_move.analytic_distribution
-        return vals
+    # pylint: disable=W8110
+    def _subcontracted_produce(self, subcontract_details):
+        # extending _prepare_subcontract_mo_vals() to pass the analytic distribution to
+        # production would cause unexpected result (production moves get duplicated),
+        # therefore, instead, we trigger the inverse method upon creation of the
+        # subcontracted production.
+        super()._subcontracted_produce(subcontract_details)
+        self.ensure_one()
+        for move, _bom in subcontract_details:
+            move._inverse_analytic_distribution()


### PR DESCRIPTION
[3242](https://www.quartile.co/web?debug=1#id=3242&action=771&model=project.task&view_type=form&menu_id=505)

Before this commit, _prepare_subcontract_mo_vals() was extended in a seemingly standard manner to pass the value of analytic distribution from the originating receipt move to the subcontracted production, however that would somehow generate duplicated stock moves (for both components and produced product) which was incorrect.

This commit fixes that problematic behavior.
