### PR TITLE
[3423][FIX] mrp_stock_owner_restriction

### DIFF
--- a/mrp_stock_owner_restriction/models/stock_move.py
+++ b/mrp_stock_owner_restriction/models/stock_move.py
@@ -17,7 +17,7 @@ class StockMove(models.Model):
         if self.production_id:
             return False
         # For chained origin moves for production component moves.
-        partner = self.move_dest_ids.raw_material_production_id.owner_id
-        if partner:
-            return partner
+        production = self.move_dest_ids.raw_material_production_id
+        if production:
+            return production.owner_id
         return super()._get_owner_for_assign()


### PR DESCRIPTION
[3423](https://www.quartile.co/web#id=3423&action=771&model=project.task&view_type=form&menu_id=505)

Fix the issue of not being able to assign inventory in replenishment moves when no owner is specified.
