### PR TITLE
[3758][IMP] stock_owner_restriction, mrp_stock_owner_restriction

### DIFF
--- a/mrp_stock_owner_restriction/models/__init__.py
+++ b/mrp_stock_owner_restriction/models/__init__.py
@@ -1,3 +1,4 @@
 from . import mrp_production
+from . import mrp_unbuild
 from . import stock_move_line
 from . import stock_move

--- a/mrp_stock_owner_restriction/models/mrp_unbuild.py
+++ b/mrp_stock_owner_restriction/models/mrp_unbuild.py
@@ -19,7 +19,8 @@ class MrpUnbuild(models.Model):
     # owner_restriction = fields.Selection(related="picking_type_id.owner_restriction")
 
     def action_validate(self):
+        owner_restriction = self.mo_id.picking_type_id.owner_restriction
         owner = self.mo_id.owner_id
-        if owner:
+        if owner and owner_restriction != "standard_behavior":
             self = self.with_context(force_restricted_owner_id=owner)
         return super().action_validate()

--- a/mrp_stock_owner_restriction/models/mrp_unbuild.py
+++ b/mrp_stock_owner_restriction/models/mrp_unbuild.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MrpUnbuild(models.Model):
+    _inherit = "mrp.unbuild"
+
+    # FIXME handle unbuild cases without MO
+    # owner_id = fields.Many2one(
+    #     "res.partner",
+    #     "Assign Owner",
+    #     readonly=True,
+    #     states={"draft": [("readonly", False)], "confirmed": [("readonly", False)]},
+    #     check_company=True,
+    #     help="Produced products will be assigned to this owner.",
+    # )
+    # owner_restriction = fields.Selection(related="picking_type_id.owner_restriction")
+
+    def action_validate(self):
+        owner = self.mo_id.owner_id
+        if owner:
+            self = self.with_context(force_restricted_owner_id=owner)
+        return super().action_validate()

--- a/mrp_stock_owner_restriction/models/stock_move.py
+++ b/mrp_stock_owner_restriction/models/stock_move.py
@@ -7,6 +7,10 @@ from odoo import models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    def _get_mo_to_unbuild(self):
+        self.ensure_one()
+        return self.consume_unbuild_id.mo_id or self.unbuild_id.mo_id
+
     def _get_owner_for_assign(self):
         self.ensure_one()
         if self.raw_material_production_id:
@@ -20,4 +24,14 @@ class StockMove(models.Model):
         production = self.move_dest_ids.raw_material_production_id
         if production:
             return production.owner_id
+        mo_to_unbuild = self._get_mo_to_unbuild()
+        if mo_to_unbuild:
+            return mo_to_unbuild.owner_id
         return super()._get_owner_for_assign()
+
+    def _get_owner_restriction(self):
+        self.ensure_one()
+        mo_to_unbuild = self._get_mo_to_unbuild()
+        if mo_to_unbuild:
+            return mo_to_unbuild.picking_type_id.owner_restriction
+        return super()._get_owner_restriction()

--- a/mrp_stock_owner_restriction/models/stock_move_line.py
+++ b/mrp_stock_owner_restriction/models/stock_move_line.py
@@ -9,7 +9,9 @@ class StockMoveLine(models.Model):
 
     def _action_done(self):
         for line in self:
-            owner = line.move_id.production_id.owner_id
+            owner = line.move_id.production_id.owner_id or self.env.context.get(
+                "force_restricted_owner_id", None
+            )
             if owner:
                 line.move_id.write({"restrict_partner_id": owner.id})
                 line.write({"owner_id": owner.id})

--- a/stock_owner_restriction/models/product.py
+++ b/stock_owner_restriction/models/product.py
@@ -14,12 +14,12 @@ class ProductProduct(models.Model):
             return super()._compute_quantities_dict(
                 lot_id, owner_id, package_id, from_date=from_date, to_date=to_date
             )
-        restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
-        if owner_id is None and restricted_owner_id is None:
+        restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+        if owner_id is None and restricted_owner is None:
             # Force owner to False if is None
             owner_id = False
-        elif restricted_owner_id:
-            owner_id = restricted_owner_id
+        elif restricted_owner:
+            owner_id = restricted_owner.id
         return super()._compute_quantities_dict(
             lot_id, owner_id, package_id, from_date=from_date, to_date=to_date
         )

--- a/stock_owner_restriction/models/stock_move.py
+++ b/stock_owner_restriction/models/stock_move.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Carlos Dauden - Tecnativa
 # Copyright 2020 Sergio Teruel - Tecnativa
+# Copyright 2023 Quartile Limited
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 
@@ -19,9 +20,16 @@ class StockMove(models.Model):
             lambda m: m.picking_type_id.owner_restriction == "standard_behavior"
         )
 
+    def _get_owner_restriction(self):
+        """This method is expected to be extended as necessary. e.g. different logic
+        needs to be applied to moves in unbuild orders.
+        """
+        self.ensure_one()
+        return self.picking_type_id.owner_restriction
+
     def _get_owner_for_assign(self):
         """This method is expected to be extended as necessary. e.g. different logic
-        needs to be applied for moves in manufacturing orders.
+        needs to be applied to moves in manufacturing orders.
         """
         self.ensure_one()
         partner = self.move_dest_ids.picking_id.owner_id
@@ -36,7 +44,8 @@ class StockMove(models.Model):
         res = super(StockMove, moves)._action_assign(force_qty=force_qty)
         dict_key = defaultdict(lambda: self.env["stock.move"])
         for move in self - moves:
-            if move.picking_type_id.owner_restriction == "unassigned_owner":
+            owner_restriction = move._get_owner_restriction()
+            if owner_restriction == "unassigned_owner":
                 dict_key[False] |= move
             else:
                 partner = move._get_owner_for_assign()

--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -42,7 +42,16 @@ class StockQuant(models.Model):
             restricted_owner = self.env.context.get("force_restricted_owner_id", None)
             if restricted_owner is not None:
                 domain = expression.AND(
-                    [domain, [("owner_id", "=", restricted_owner.id)]]
+                    [
+                        domain,
+                        [
+                            (
+                                "owner_id",
+                                "=",
+                                restricted_owner and restricted_owner.id or False,
+                            )
+                        ],
+                    ]
                 )
         return super(StockQuant, self).read_group(
             domain,

--- a/stock_owner_restriction/models/stock_quant.py
+++ b/stock_owner_restriction/models/stock_quant.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Carlos Dauden - Tecnativa
 # Copyright 2020 Sergio Teruel - Tecnativa
+# Copyright 2023 Quartile Limited
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, models
 from odoo.osv import expression
@@ -25,20 +26,24 @@ class StockQuant(models.Model):
             owner_id=owner_id,
             strict=strict,
         )
-        restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
-        if owner_id is None or restricted_owner_id is None:
+        restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+        if owner_id is None or restricted_owner is None:
             return records
         return records.filtered(
-            lambda q: q.owner_id == (restricted_owner_id or self.env["res.partner"])
+            lambda q: q.owner_id == (restricted_owner or self.env["res.partner"])
         )
 
     @api.model
     def read_group(
         self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True
     ):
-        restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
-        if restricted_owner_id is not None:
-            domain = expression.AND([domain, [("owner_id", "=", restricted_owner_id)]])
+        owner_in_domain = any(t[0] == "owner_id" for t in domain)
+        if not owner_in_domain:
+            restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+            if restricted_owner is not None:
+                domain = expression.AND(
+                    [domain, [("owner_id", "=", restricted_owner.id)]]
+                )
         return super(StockQuant, self).read_group(
             domain,
             fields,
@@ -60,9 +65,9 @@ class StockQuant(models.Model):
         strict=False,
         allow_negative=False,
     ):
-        restricted_owner_id = self.env.context.get("force_restricted_owner_id", None)
-        if not owner_id and restricted_owner_id is not None:
-            owner_id = restricted_owner_id
+        restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+        if not owner_id and restricted_owner is not None:
+            owner_id = restricted_owner
         return super()._get_available_quantity(
             product_id,
             location_id,
@@ -71,4 +76,52 @@ class StockQuant(models.Model):
             owner_id=owner_id,
             strict=strict,
             allow_negative=allow_negative,
+        )
+
+    @api.model
+    def _update_available_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        in_date=None,
+    ):
+        restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+        if not owner_id and restricted_owner is not None:
+            owner_id = restricted_owner
+        return super()._update_available_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            in_date=in_date,
+        )
+
+    @api.model
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        restricted_owner = self.env.context.get("force_restricted_owner_id", None)
+        if not owner_id and restricted_owner is not None:
+            owner_id = restricted_owner
+        return super()._update_reserved_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
         )


### PR DESCRIPTION
[3758](https://www.quartile.co/web#id=3758&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

### stock_owner_restriction:

[IMP] stock_owner_restriction: increase method coverage

Extend following methods for the scenario where owner restriction should be forced:

- _update_available_quantity() (stock.quant)
- _update_reserved_quantity() (stock.quant)

Split lines to identify the owner_restriction setting into separate method for
better extensibility.

Fix read_group() (stock.quant) which was incorrectly assigning the owner record
in the domain instead of the id.

### mrp_stock_owner_restriction:

[IMP] mrp_stock_owner_restriction: add handling of umbuild orders
