### PR TITLE
[4406][IMP] mrp_production_quant_manual_assign: skip _check_qty()

### DIFF
--- a/mrp_production_quant_manual_assign/wizards/assign_manual_quants.py
+++ b/mrp_production_quant_manual_assign/wizards/assign_manual_quants.py
@@ -25,6 +25,14 @@ class AssignManualQuants(models.TransientModel):
         res.update({"is_production_single_lot": self._is_production_single_lot(move)})
         return res
 
+    @api.constrains("quants_lines")
+    def _check_qty(self):
+        # If the move is that of a production component, skip the check and let the
+        # standard check based on Flexible Consumption do the job.
+        if self.move_id.raw_material_production_id:
+            return
+        return super()._check_qty()
+
     @api.model
     def _prepare_wizard_line(self, move, quant):
         line = super()._prepare_wizard_line(move, quant)


### PR DESCRIPTION
[4406](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=4406)

assign.manual.quants._check_qty() would show an error when you tried to consume more than you were supposed to, however this should not be applied in the manufacturing context where component losses/overcomsumption should be added to the cost of produced product.

We let the standard check logic based on the BoM configuration ('Flexible Consumption')' handle the case where discrepancy arises.