### PR TITLE
[4346][FIX] mrp_subcontracting_analytic: revert 1345a6d

### DIFF
--- a/mrp_subcontracting_analytic/models/stock_picking.py
+++ b/mrp_subcontracting_analytic/models/stock_picking.py
@@ -7,13 +7,7 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    # pylint: disable=W8110
-    def _subcontracted_produce(self, subcontract_details):
-        # extending _prepare_subcontract_mo_vals() to pass the analytic distribution to
-        # production would cause unexpected result (production moves get duplicated),
-        # therefore, instead, we trigger the inverse method upon creation of the
-        # subcontracted production.
-        super()._subcontracted_produce(subcontract_details)
-        self.ensure_one()
-        for move, _bom in subcontract_details:
-            move._inverse_analytic_distribution()
+    def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
+        vals = super()._prepare_subcontract_mo_vals(subcontract_move, bom)
+        vals["analytic_distribution"] = subcontract_move.analytic_distribution
+        return vals


### PR DESCRIPTION
[4346](https://www.quartile.co/web#id=4346&cids=3&menu_id=506&action=1457&model=project.task&view_type=form)

We need to include analytic_distribution in the vals used to create MO, instead of post-processing the update, because there is issue with passing down the analytic distribution to procurements when procurement_mto_analytic is used.

The issue reported in the message of 1345a6d does not seem to reproduce with this change.