### PR TITLE
[16.0][UPD] dotfiles

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.19.2
+_commit: v1.20
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 ci: GitHub
 convert_readme_fragments_to_markdown: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: f71041f22b8cd68cf7c77b73a14ca8d8cd190a60
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons


### PR DESCRIPTION
Update with latest OCA versions.
I intentionally disabled to generate readme and checking website because xxx-oca repos will host from different website and    will lost the real path of module if we generate the readme.

https://github.com/qrtl/axls-oca/blob/6c409566d1467d47a1e8d1b464cd03429831a739/.pre-commit-config.yaml#L44-L52