### PR TITLE
[3465][FIX] analytic_mixin_analytic_account: analytic_account_ids

### DIFF
--- a/analytic_mixin_analytic_account/models/analytic_mixin.py
+++ b/analytic_mixin_analytic_account/models/analytic_mixin.py
@@ -10,6 +10,7 @@ class AnalyticMixin(models.AbstractModel):
     analytic_account_ids = fields.Many2many(
         "account.analytic.account",
         compute="_compute_analytic_account_ids",
+        context={"active_test": False},
         string="Analytic Accounts",
         help="Analytic accounts computed from analytic distribution.",
     )
@@ -20,14 +21,13 @@ class AnalyticMixin(models.AbstractModel):
     )
 
     def _compute_analytic_account_ids(self):
-        analytic_account = self.env["account.analytic.account"]
         for rec in self:
             if not rec.analytic_distribution:
-                rec.analytic_account_ids = analytic_account
+                rec.analytic_account_ids = False
                 rec.analytic_account_names = False
                 continue
             account_ids = [int(key) for key in rec.analytic_distribution.keys()]
-            rec.analytic_account_ids = analytic_account.browse(account_ids)
+            rec.analytic_account_ids = [(6, 0, account_ids)]
             rec.analytic_account_names = ", ".join(
                 account.display_name for account in rec.analytic_account_ids
             )


### PR DESCRIPTION
[3465](https://www.quartile.co/web#id=3465&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

Before this commit, archived analytic accounts were not included in the assignment of analytic_account_ids and analytic_account_names to the record.
