### PR TITLE
[5016][FIX] mrp_subcontracting_receipt_set_quantity: fix not assigning value if there is subcontracted product and normal product in receipt

### DIFF
--- a/mrp_subcontracting_receipt_set_quantity/models/stock_move.py
+++ b/mrp_subcontracting_receipt_set_quantity/models/stock_move.py
@@ -13,4 +13,5 @@ class StockMove(models.Model):
                 move = move.with_context(move_dest_qty=move.product_uom_qty)
                 self -= move
                 super(StockMove, move)._set_quantities_to_reservation()
-        return super(StockMove, self)._set_quantities_to_reservation()
+        super()._set_quantities_to_reservation()
+        return

--- a/mrp_subcontracting_receipt_set_quantity/models/stock_move.py
+++ b/mrp_subcontracting_receipt_set_quantity/models/stock_move.py
@@ -12,5 +12,5 @@ class StockMove(models.Model):
             if move.is_subcontract:
                 move = move.with_context(move_dest_qty=move.product_uom_qty)
                 self -= move
-                return super(StockMove, move)._set_quantities_to_reservation()
-        return super()._set_quantities_to_reservation()
+                super(StockMove, move)._set_quantities_to_reservation()
+        return super(StockMove, self)._set_quantities_to_reservation()


### PR DESCRIPTION
[5016](https://www.quartile.co/web#id=5016&cids=3&menu_id=505&action=1457&model=project.task&view_type=form)