### PR TITLE
[3715][IMP] base_tier_validation: reflect oca changes

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -444,7 +444,7 @@ class TierValidation(models.AbstractModel):
                     }
                 )
             if rec._allow_to_remove_reviews(vals):
-                rec.mapped("review_ids").unlink()
+                rec._remove_reviews()
         return super(TierValidation, self).write(vals)
 
     def _allow_to_remove_reviews(self, values):
@@ -754,7 +754,7 @@ class TierValidation(models.AbstractModel):
                         .mapped("partner_id")
                         .ids
                     )
-                rec.mapped("review_ids").unlink()
+                rec._remove_reviews()
                 if to_update_counter:
                     self._update_counter({"review_deleted": True})
             if partners_to_notify_ids:
@@ -785,6 +785,10 @@ class TierValidation(models.AbstractModel):
         channel = "base.tier.validation/updated"
         notifications.append([self.env.user.partner_id, channel, review_counter])
         self.env["bus.bus"]._sendmany(notifications)
+
+    def _remove_reviews(self):
+        """Remove the reviews. Hook to allow overriding the removal behavior."""
+        self.review_ids.unlink()
 
     def unlink(self):
         self.mapped("review_ids").unlink()


### PR DESCRIPTION
Reflect [OCA/server-ux#1307](https://github.com/OCA/server-ux/pull/1307) into base_tier_validation.

Review removal in `write()` and `restart_validation()` is extracted into a dedicated `_remove_reviews()` method, providing a hook so other modules can override the removal behavior (e.g. archive `tier.review` records as history instead of deleting them).

Stacked on top of #150 (which adds base_tier_validation).