### PR TITLE
[FIX] stock_valuation_fifo_lot: reset is_force_fifo_candidate

### DIFF
--- a/stock_valuation_fifo_lot/__manifest__.py
+++ b/stock_valuation_fifo_lot/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Stock Valuation Fifo Lot",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Warehouse Management",
     "development_status": "Alpha",
     "license": "AGPL-3",

--- a/stock_valuation_fifo_lot/migrations/16.0.1.0.2/post-migration.py
+++ b/stock_valuation_fifo_lot/migrations/16.0.1.0.2/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # is_force_fifo_candidate used to be left untouched (instead of being set to
+    # False) when the lot had no remaining quantity, so stale True values may
+    # remain in the database.
+    lots = env["stock.lot"].search([("is_force_fifo_candidate", "=", True)])
+    if not lots:
+        return
+    env.add_to_compute(lots._fields["is_force_fifo_candidate"], lots)
+    lots.flush_recordset(["is_force_fifo_candidate"])

--- a/stock_valuation_fifo_lot/models/stock_lot.py
+++ b/stock_valuation_fifo_lot/models/stock_lot.py
@@ -19,6 +19,7 @@ class StockLot(models.Model):
     )
     def _compute_is_force_fifo_candidate(self):
         for lot in self:
+            lot.is_force_fifo_candidate = False
             if lot.product_id.cost_method != "fifo":
                 continue
             if not self.env["stock.move.line"].search(

--- a/stock_valuation_fifo_lot/tests/test_stock_valuation_fifo_lot.py
+++ b/stock_valuation_fifo_lot/tests/test_stock_valuation_fifo_lot.py
@@ -86,6 +86,10 @@ class TestStockValuationFifoLot(TestStockValuationFifoCommon):
         ml_in_002.qty_consumed = 0.0
         self.assertEqual(ml_in_002.qty_remaining, 5.0)
         self.assertEqual(ml_in_002.value_remaining, 500.0)
+        # Lot 002 has no on-hand quantity but still has a remaining value, so it can
+        # be selected as a forced FIFO lot.
+        lot_002 = ml_in_002.lot_id
+        self.assertTrue(lot_002.is_force_fifo_candidate)
         # Create delivery for lot 001
         with self.assertRaises(UserError):
             self.create_picking("out", ["001"], ml_qty=5.0)
@@ -93,6 +97,9 @@ class TestStockValuationFifoLot(TestStockValuationFifoCommon):
             "out", ["001"], ml_qty=5.0, force_lot_name="002"
         )
         self.assertEqual(move_out_001.stock_valuation_layer_ids.value, -500.0)
+        # Lot 002 is no longer a candidate once its remaining value is consumed.
+        self.assertEqual(ml_in_002.qty_remaining, 0.0)
+        self.assertFalse(lot_002.is_force_fifo_candidate)
 
     def test_avco_product_receipt(self):
         self.product.categ_id.property_cost_method = "average"


### PR DESCRIPTION
`_compute_is_force_fifo_candidate` did not assign any value on its early-exit paths.
As the field is stored, a lot that had once qualified as a candidate kept its `True`
value in the database after its remaining FIFO quantity was consumed, so it kept
being offered in the **Force FIFO Lot/Serial** dropdown even though it no longer
carried any remaining value.

(In Odoo 16 an unassigned stored computed field only falls back to `False` in the
cache — `dirty` is not set, so the column is never updated.)

Changes:
- Assign `False` before the early exits in `_compute_is_force_fifo_candidate`.
- Add a `16.0.1.0.2` post-migration recomputing the lots currently flagged.
- Extend `test_force_fifo_lot_id` to cover the flag before/after the forced FIFO
  consumption (it fails without the fix: `AssertionError: True is not false`).

Assisted-by: Claude Opus 5